### PR TITLE
[FIX] bi_sql_editor: allow to remove draft sql views

### DIFF
--- a/bi_sql_editor/models/bi_sql_view.py
+++ b/bi_sql_editor/models/bi_sql_view.py
@@ -293,7 +293,8 @@ class BiSQLView(models.Model):
                     "If you want to delete them, first set them to draft."
                 )
             )
-        self.cron_id.unlink()
+        if self.cron_id:
+            self.cron_id.unlink()
         return super(BiSQLView, self).unlink()
 
     def copy(self, default=None):


### PR DESCRIPTION
This PR fixes the following Issue.

Steps to reproduce.
-

- Create a SQL view.
- Save it.
- Don't confirm it and do nothing.
- Remove it.

Expected behavior:
-

The view must be deleted.

Current behavior:
-

It raises the following error
```python
Error:
Odoo Server Error

Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/home/odoo/src/odoo/odoo/http.py", line 685, in dispatch
    result = self._call_function(**self.params)
  File "/home/odoo/src/odoo/odoo/http.py", line 361, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/http.py", line 349, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/odoo/src/odoo/odoo/http.py", line 914, in __call__
    return self.method(*args, **kw)
  File "/home/odoo/src/odoo/odoo/http.py", line 533, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/src/odoo/addons/web/controllers/main.py", line 1394, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/odoo/src/odoo/addons/web/controllers/main.py", line 1386, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/src/odoo/odoo/api.py", line 399, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/odoo/src/odoo/odoo/api.py", line 386, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/src/user/reporting-engine/bi_sql_editor/models/bi_sql_view.py", line 296, in unlink
    self.cron_id.unlink()
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_cron.py", line 307, in unlink
    self._try_lock()
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_cron.py", line 294, in _try_lock
    self._cr.execute("""SELECT id FROM "%s" WHERE id IN %%s FOR UPDATE NOWAIT""" % self._table,
  File "<decorator-gen-3>", line 2, in execute
  File "/home/odoo/src/odoo/odoo/sql_db.py", line 101, in check
    return f(self, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/sql_db.py", line 298, in execute
    res = self._obj.execute(query, params)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/http.py", line 641, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/odoo/src/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
psycopg2.errors.SyntaxError: syntax error at or near ")"
LINE 1: SELECT id FROM "ir_cron" WHERE id IN () FOR UPDATE NOWAIT
                                              ^
```